### PR TITLE
Fixed #95

### DIFF
--- a/acme_diags/acme_diags_driver.py
+++ b/acme_diags/acme_diags_driver.py
@@ -50,14 +50,13 @@ def run_diag(parameters):
         mod_str = 'acme_diags.driver.{}_driver'.format(set_name)
         try:
             module = importlib.import_module(mod_str)
-        except ImportError as e:
-            print('Import error in {}: {}'.format(mod_str, e))
-            print('Set {} is not supported yet. Please give us time.'.format(set_name))
+            print('Starting to run ACME Diagnostics.')
+            single_result = module.run_diag(parameters)
+            results.append(single_result)
+        except Exception as e:
+            print('Error in {}: {}'.format(mod_str, e))
             continue
 
-        print('Starting to run ACME Diagnostics.')
-        single_result = module.run_diag(parameters)
-        results.append(single_result)
     return results
 
 
@@ -123,8 +122,11 @@ if __name__ == '__main__':
 
     parameters = _collaspse_results(parameters)
 
-    pth = os.path.join(parameters[0].results_dir, 'viewer')
-    if not os.path.exists(pth):
-        os.makedirs(pth)
+    if parameters:
+        pth = os.path.join(parameters[0].results_dir, 'viewer')
+        if not os.path.exists(pth):
+            os.makedirs(pth)
 
-    create_viewer(pth, parameters, parameters[0].output_format[0])
+        create_viewer(pth, parameters, parameters[0].output_format[0])
+    else:
+        print('There was not a single valid diagnostics run, no viewer created')

--- a/acme_diags/plot/__init__.py
+++ b/acme_diags/plot/__init__.py
@@ -40,8 +40,10 @@ def plot(set_num, ref, test, diff, metrics_dict, parameter):
                 'Invalid backend, choose either "vcs" or "matplotlib"/"mpl"/"cartopy"')
 
         plot_fcn = _get_plot_fcn(parameter.backend, set_num)
-        plot_fcn(ref, test, diff, metrics_dict, parameter)
-
+        try:
+            plot_fcn(ref, test, diff, metrics_dict, parameter)
+        except Exception as e:
+            print('Exception {} while plotting {} with backend {}'.format(e, set_num, parameter.backend))
 
 def get_colormap(colormap, parameters):
     """Get the colormap (string, list for vcs, or mpl colormap obj), which can be


### PR DESCRIPTION
Running with the below Python and cfg script on `aims4`, we see that the diags will continue, even though `THIS_IS_NOT_A_REAL_VAR` isn't a valid variable.

```python
# something.py
reference_data_path = '/p/cscratch/acme/data/obs_for_acme_diags/'
test_data_path = '/p/cscratch/acme/data/test_model_data_for_acme_diags/'
test_name = '20161118.beta0.FC5COSP.ne30_ne30.edison'

backend = 'mpl'

results_dir = 'bad_var_fix'
```

```ini
# something.cfg
[Diags 1]
sets= ["lat_lon"]
case_id= "GPCP_v2.2"
variables=["THIS_IS_NOT_A_REAL_VAR"]
ref_name= "GPCP_v2.2"
reference_name= "GPCP (yrs1979-2014)"
seasons= ["ANN", "DJF", "MAM", "JJA", "SON"]
regions= ["global"]
test_colormap= "WhiteBlueGreenYellowRed.rgb"
reference_colormap= "WhiteBlueGreenYellowRed.rgb"
diff_colormap = "BrBG"
contour_levels = [0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16]
diff_levels = [-5, -4, -3, -2, -1, -0.5, 0.5, 1, 2, 3, 4, 5]
```

The output is:
```
(acme_diags_env_maybe_broken) shaheen2@aims4:~$ acme_diags_driver.py -p quickguide-badvar.py -d quickguide-badvar.cfg 
Starting to run ACME Diagnostics.
test file: /p/cscratch/acme/data/test_model_data_for_acme_diags/20161118.beta0.FC5COSP.ne30_ne30.edison_ANN_climo.nc
reference file: /p/cscratch/acme/data/obs_for_acme_diags/GPCP_v2.2_ANN_climo.nc
Variable: THIS_IS_NOT_A_REAL_VAR
Error in acme_diags.driver.lat_lon_driver: The variable THIS_IS_NOT_A_REAL_VAR was not in the derived variables dictionary
There was not a single valid diagnostics run, no viewer created
```